### PR TITLE
Add cooldown for regeneration

### DIFF
--- a/realmscraft/data/death/functions/ondeath.mcfunction
+++ b/realmscraft/data/death/functions/ondeath.mcfunction
@@ -23,5 +23,5 @@ execute as @e[type=zombie,x=1,y=1,z=2,distance=..2] run function death:corpsesco
 execute at @e[type=armor_stand,name="death location"] run tp @e[type=item,distance=..2] 1.5 4 3.5
 
 #if player has regeneration feat, begin 2 min corpse regen
-execute as @s[tag=regeneration] run scoreboard players set @e[type=zombie,x=1,y=1,z=2,distance=..2] regenerateTime 2400
-execute as @s[tag=regeneration] run tag @e[type=zombie,x=1,y=1,z=2,distance=..2] add regenerate
+execute as @s[tag=regeneration,tag=!cooldownRegen] run scoreboard players set @e[type=zombie,x=1,y=1,z=2,distance=..2] regenerateTime 2400
+execute as @s[tag=regeneration,tag=!cooldownRegen] run tag @e[type=zombie,x=1,y=1,z=2,distance=..2] add regenerate

--- a/realmscraft/data/death/functions/ondeath.mcfunction
+++ b/realmscraft/data/death/functions/ondeath.mcfunction
@@ -23,5 +23,4 @@ execute as @e[type=zombie,x=1,y=1,z=2,distance=..2] run function death:corpsesco
 execute at @e[type=armor_stand,name="death location"] run tp @e[type=item,distance=..2] 1.5 4 3.5
 
 #if player has regeneration feat, begin 2 min corpse regen
-execute as @s[tag=regeneration,tag=!cooldownRegen] run scoreboard players set @e[type=zombie,x=1,y=1,z=2,distance=..2] regenerateTime 2400
-execute as @s[tag=regeneration,tag=!cooldownRegen] run tag @e[type=zombie,x=1,y=1,z=2,distance=..2] add regenerate
+execute as @s[tag=regeneration,tag=!cooldownRegen] run function death:regenspell

--- a/realmscraft/data/death/functions/regenspell.mcfunction
+++ b/realmscraft/data/death/functions/regenspell.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set @e[type=zombie,x=1,y=1,z=2,distance=..2] regenerateTime 2400
+tag @e[type=zombie,x=1,y=1,z=2,distance=..2] add regenerate
+tag @e[type=zombie,x=1,y=1,z=2,distance=..2] add regenSpell

--- a/realmscraft/data/death/functions/revive.mcfunction
+++ b/realmscraft/data/death/functions/revive.mcfunction
@@ -3,8 +3,7 @@ tp @a[tag=dead,scores={deathLine=0}] @s
 gamemode adventure @a[gamemode=spectator,tag=dead,tag=deathwatch,scores={deathLine=0}]
 
 # Start regeneration spell cooldown (if appropriate)
-execute as @s[scores={regenerateTime=0}] run tag @a[tag=dead,tag=regeneration,scores={deathLine=0}] add cooldownRegen
-execute as @s[scores={regenerateTime=0}] run scoreboard players set @a[tag=dead,tag=regeneration,scores={deathLine=0}] cooldownRegen 600
+execute as @s[scores={regenerateTime=0},tag=regenSpell] run scoreboard players set @a[tag=dead,tag=regeneration,scores={deathLine=0}] cooldownRegen 600
 
 tag @a[tag=dead,scores={deathLine=0}] remove dead
 scoreboard players operation @a deathLine += @s deathLine

--- a/realmscraft/data/death/functions/revive.mcfunction
+++ b/realmscraft/data/death/functions/revive.mcfunction
@@ -4,7 +4,7 @@ gamemode adventure @a[gamemode=spectator,tag=dead,tag=deathwatch,scores={deathLi
 
 # Start regeneration spell cooldown (if appropriate)
 execute as @s[scores={regenerateTime=0}] run tag @a[tag=dead,tag=regeneration,scores={deathLine=0}] add cooldownRegen
-execute as @s[scores={regenerateTime=0}] run scoreboard players set @a[tag=dead,tag=regeneration,scores={deathLine=0}] cooldownRegen 300
+execute as @s[scores={regenerateTime=0}] run scoreboard players set @a[tag=dead,tag=regeneration,scores={deathLine=0}] cooldownRegen 600
 
 tag @a[tag=dead,scores={deathLine=0}] remove dead
 scoreboard players operation @a deathLine += @s deathLine

--- a/realmscraft/data/death/functions/revive.mcfunction
+++ b/realmscraft/data/death/functions/revive.mcfunction
@@ -1,6 +1,11 @@
 scoreboard players operation @a deathLine -= @s deathLine
 tp @a[tag=dead,scores={deathLine=0}] @s
 gamemode adventure @a[gamemode=spectator,tag=dead,tag=deathwatch,scores={deathLine=0}]
+
+# Start regeneration spell cooldown (if appropriate)
+execute as @s[scores={regenerateTime=0}] run tag @a[tag=dead,tag=regeneration,scores={deathLine=0}] add cooldownRegen
+execute as @s[scores={regenerateTime=0}] run scoreboard players set @a[tag=dead,tag=regeneration,scores={deathLine=0}] cooldownRegen 300
+
 tag @a[tag=dead,scores={deathLine=0}] remove dead
 scoreboard players operation @a deathLine += @s deathLine
 scoreboard players set @a[tag=!dead] deathLine 0

--- a/realmscraft/data/func/functions/cooldown.mcfunction
+++ b/realmscraft/data/func/functions/cooldown.mcfunction
@@ -9,8 +9,8 @@ scoreboard players remove @a[scores={cooldownGuidance=1..}] cooldownGuidance 1
 scoreboard players remove @a[scores={cooldownVision=1..}] cooldownVision 1
 scoreboard players remove @a[scores={cooldownRD=1..}] cooldownRD 1
 scoreboard players remove @a[scores={cooldownSoL=1..}] cooldownSoL 1
-scoreboard players remove @a[scores={cooldownRegen=1..},tag=!dead] cooldownRegen 1
 
+execute as @a[scores={cooldownRegen=1..}] run function func:cooldownregen
 
 execute as @a[scores={cooldownHeal=1}] run function func:cooldownheal
 execute as @a[scores={cooldownRA=1}] run function func:cooldownrepair
@@ -23,4 +23,3 @@ execute as @a[scores={cooldownGuidance=1}] run function func:cooldownguide
 execute as @a[scores={cooldownVision=1}] run function func:cooldownvision
 execute as @a[scores={cooldownRD=1}] run function func:cooldownrd
 execute as @a[scores={cooldownSoL=1}] run function func:cooldownsol
-execute as @a[scores={cooldownRegen=1}] run function func:cooldownregen

--- a/realmscraft/data/func/functions/cooldown.mcfunction
+++ b/realmscraft/data/func/functions/cooldown.mcfunction
@@ -9,6 +9,7 @@ scoreboard players remove @a[scores={cooldownGuidance=1..}] cooldownGuidance 1
 scoreboard players remove @a[scores={cooldownVision=1..}] cooldownVision 1
 scoreboard players remove @a[scores={cooldownRD=1..}] cooldownRD 1
 scoreboard players remove @a[scores={cooldownSoL=1..}] cooldownSoL 1
+scoreboard players remove @a[scores={cooldownRegen=1..}] cooldownRegen 1
 
 
 execute as @a[scores={cooldownHeal=1}] run function func:cooldownheal
@@ -22,3 +23,4 @@ execute as @a[scores={cooldownGuidance=1}] run function func:cooldownguide
 execute as @a[scores={cooldownVision=1}] run function func:cooldownvision
 execute as @a[scores={cooldownRD=1}] run function func:cooldownrd
 execute as @a[scores={cooldownSoL=1}] run function func:cooldownsol
+execute as @a[scores={cooldownRegen=1}] run function func:cooldownregen

--- a/realmscraft/data/func/functions/cooldown.mcfunction
+++ b/realmscraft/data/func/functions/cooldown.mcfunction
@@ -9,7 +9,7 @@ scoreboard players remove @a[scores={cooldownGuidance=1..}] cooldownGuidance 1
 scoreboard players remove @a[scores={cooldownVision=1..}] cooldownVision 1
 scoreboard players remove @a[scores={cooldownRD=1..}] cooldownRD 1
 scoreboard players remove @a[scores={cooldownSoL=1..}] cooldownSoL 1
-scoreboard players remove @a[scores={cooldownRegen=1..}] cooldownRegen 1
+scoreboard players remove @a[scores={cooldownRegen=1..},tag=!dead] cooldownRegen 1
 
 
 execute as @a[scores={cooldownHeal=1}] run function func:cooldownheal

--- a/realmscraft/data/func/functions/cooldownregen.mcfunction
+++ b/realmscraft/data/func/functions/cooldownregen.mcfunction
@@ -1,1 +1,8 @@
+scoreboard players remove @s[nbt={SelectedItem:{id:"minecraft:carrot_on_a_stick",tag:{display:{Name:"\"Recast Regeneration\""}}}},scores={cooldownRegen=2..},tag=!dead] cooldownRegen 1
+
+give @s[tag=!cooldownRegen] minecraft:carrot_on_a_stick{display:{Name:"\"Recast Regeneration\"",Lore:["\"Spell Focus\""]}}
+tag @s[tag=!cooldownRegen] add cooldownRegen
+
 tag @s[scores={cooldownRegen=1}] remove cooldownRegen
+clear @s[scores={cooldownRegen=1}] minecraft:carrot_on_a_stick{display:{Name:"\"Recast Regeneration\""}}
+scoreboard players reset @s[scores={cooldownRegen=1}] cooldownRegen

--- a/realmscraft/data/func/functions/cooldownregen.mcfunction
+++ b/realmscraft/data/func/functions/cooldownregen.mcfunction
@@ -1,0 +1,1 @@
+tag @s[scores={cooldownRegen=1}] remove cooldownRegen

--- a/realmscraft/data/rcq/functions/setup.mcfunction
+++ b/realmscraft/data/rcq/functions/setup.mcfunction
@@ -32,6 +32,7 @@ scoreboard objectives add cooldownGuidance dummy
 scoreboard objectives add cooldownVision dummy
 scoreboard objectives add cooldownRD dummy
 scoreboard objectives add cooldownSoL dummy
+scoreboard objectives add cooldownRegen dummy
 scoreboard objectives add beckoned dummy
 scoreboard objectives add regenerateTime dummy
 


### PR DESCRIPTION
Adding a 30 second cooldown after regenerating.

* Cooldown should not start unless they regenerated (i.e. if raised).
* If they regenerated from SoL, the cooldown would be applied.
    * Should we be tagging the 'corpse' with the regeneration source?
* There is no display indicating the cooldown, should there be one?
    * Can/should we display the cooldown countdown?
    * Should we send them a message when they can regen again?
    * Should we have some sort of item in the inventory like other spells?
* Other thought: should they have to do something to reactivate regen (like crouching for the 30 seconds), raher than a straight cooldown?